### PR TITLE
Update 0.2.11

### DIFF
--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -19,7 +19,9 @@ quote = "1.0"
 syn = "1.0"
 
 [features]
+default = ["hex_fns"]
 slice_fns = []
+hex_fns = []
 
 [dev-dependencies]
 anyhow = "1.0.51"

--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd-derive"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]

--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd-derive"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]
@@ -19,10 +19,10 @@ quote = "1.0"
 syn = "1.0"
 
 [features]
-default = ["hex_fns"]
+default = []
 slice_fns = []
 hex_fns = []
 
 [dev-dependencies]
 anyhow = "1.0.51"
-bondrewd = { path = "../bondrewd", features = ["derive"] }
+bondrewd = { path = "../bondrewd", features = ["derive", "slice_fns", "hex_fns"] }

--- a/bondrewd-derive/examples/complex.rs
+++ b/bondrewd-derive/examples/complex.rs
@@ -1,4 +1,4 @@
-use bondrewd::{BitfieldEnum, Bitfields};
+use bondrewd::*;
 #[cfg(feature = "slice_fns")]
 use bondrewd::BitfieldSliceError;
 

--- a/bondrewd-derive/examples/complex.rs
+++ b/bondrewd-derive/examples/complex.rs
@@ -1,6 +1,4 @@
 use bondrewd::*;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
 
 #[derive(BitfieldEnum, Clone, Eq, PartialEq, Debug)]
 enum EyeColor {
@@ -66,5 +64,4 @@ fn main() {
     let bytes = person.clone().into_bytes();
     let cloned_and_transferred_person = PersonStuff::from_bytes(bytes);
     assert_eq!(cloned_and_transferred_person, person);
-    println!("");
 }

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -37,14 +37,9 @@ pub struct CcsdsPacketHeader {
 }
 
 #[derive(Bitfields)]
-#[bondrewd(default_endianness = "be")]
 struct Simple {
     #[bondrewd(bit_length = 3)]
     one: u8,
-    #[bondrewd(bit_length = 19)]
-    two: u32,
-    #[bondrewd(bit_length = 14)]
-    six: u16,
     #[bondrewd(bit_length = 4)]
     four: u8,
 }

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -1,4 +1,4 @@
-use bondrewd::{BitfieldEnum, Bitfields};
+use bondrewd::*;
 #[cfg(feature = "slice_fns")]
 use bondrewd::BitfieldSliceError;
 

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -1,6 +1,4 @@
 use bondrewd::*;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
 
 #[derive(BitfieldEnum, Clone, PartialEq, Eq, Debug)]
 pub enum CcsdsPacketSequenceFlags {
@@ -36,13 +34,48 @@ pub struct CcsdsPacketHeader {
     pub(crate) packet_data_length: u16,
 }
 
-#[derive(Bitfields)]
+#[derive(Bitfields, Clone)]
 struct Simple {
     #[bondrewd(bit_length = 3)]
     one: u8,
     #[bondrewd(bit_length = 4)]
     four: u8,
-    asdf: [i8;6],
+    asdf: i8,
+}
+
+/*#[derive(Bitfields, Clone, Debug, PartialEq)]
+#[bondrewd(read_from = "lsb0", enforce_bits = 3)]
+pub struct StatusMagnetometer {
+    int_mtm1: bool,
+    int_mtm2: bool,
+    ext_mtm: bool,
+}
+
+/// Response to a Get Mtm Reading command - returns data in the Telemetry::Magnetometer format (separate as non-unit enums are not supported by GraphQL)
+/// This includes status and readings for all magnetometers
+#[derive(Bitfields, Clone, Debug, PartialEq)]
+#[bondrewd(default_endianness = "msb")]
+pub struct Magnetometer {
+    pub timestamp: u64,
+    #[bondrewd(struct_size = 1)]
+    pub status: StatusMagnetometer,
+    #[bondrewd(block_byte_length = 6)]
+    pub int_mtm1_xyz: [i16; 3],
+    #[bondrewd(block_byte_length = 6)]
+    pub int_mtm2_xyz: [i16; 3],
+    #[bondrewd(block_byte_length = 6)]
+    pub ext_mtm_xyz: [i16; 3],
+}*/
+
+#[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
+#[bondrewd(default_endianness = "be")]
+struct SimpleWithBlockArray {
+    #[bondrewd(bit_length = 3)]
+    one: u8,
+    #[bondrewd(block_bit_length = 9)]
+    two: [u8; 2],
+    #[bondrewd(bit_length = 4)]
+    three: u8,
 }
 
 fn main() {

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -42,6 +42,7 @@ struct Simple {
     one: u8,
     #[bondrewd(bit_length = 4)]
     four: u8,
+    asdf: [i8;6],
 }
 
 fn main() {

--- a/bondrewd-derive/src/structs/common.rs
+++ b/bondrewd-derive/src/structs/common.rs
@@ -513,6 +513,7 @@ impl Iterator for ElementSubFieldIter {
     }
 }
 
+#[derive(Debug)]
 pub struct BlockSubFieldIter {
     pub outer_ident: Box<Ident>,
     pub endianness: Box<Endianness>,
@@ -533,15 +534,10 @@ impl Iterator for BlockSubFieldIter {
             if ty_size > self.bit_length {
                 ty_size = self.bit_length;
             }
-            let start = if self.length > 0 {
-                self.starting_bit_index
-                    + (self.bit_length % ty_size)
-                    + ((self.length - 1) * ty_size)
-            } else {
-                self.starting_bit_index
-            };
+            let start = self.starting_bit_index;
+            self.starting_bit_index = start + ty_size;
             let attrs = FieldAttrs {
-                bit_range: start..start + ty_size,
+                bit_range: start..(start + ty_size),
                 endianness: self.endianness.clone(),
                 reserve: false,
             };
@@ -702,6 +698,7 @@ impl FieldInfo {
     }
 }
 
+#[derive(Debug)]
 pub enum StructEnforcement {
     /// there is no enforcement so if bits are unused then it will act like they are a reserve field
     NoRules,
@@ -711,6 +708,7 @@ pub enum StructEnforcement {
     EnforceBitAmount(usize),
 }
 
+#[derive(Debug)]
 pub struct StructInfo {
     pub name: Ident,
     /// if false then bit 0 is the Most Significant Bit meaning the first values first bit will start there.

--- a/bondrewd-derive/src/structs/common.rs
+++ b/bondrewd-derive/src/structs/common.rs
@@ -272,10 +272,59 @@ impl FieldDataType {
                                     )
                                 }
                                 _ => {
-                                    return Err(Error::new(
-                                        array_path.bracket_token.span,
-                                        "Please Use array-bit-length (Bit-Block) or element-bit-length (List of nameless Fields of the same type) for defining array packing behavior",
-                                    ));
+                                    
+                                    let mut sub_attrs = attrs.clone();
+                                    if let Type::Array(_) = array_path.elem.as_ref() {
+                                    } else {
+                                        sub_attrs.ty = FieldAttrBuilderType::None;
+                                    }
+                                    let sub_ty = Self::parse(
+                                        &array_path.elem,
+                                        &mut sub_attrs,
+                                        &ident,
+                                        default_endianess,
+                                    )?;
+
+                                    attrs.bit_range = match std::mem::take(&mut attrs.bit_range) {
+                                        FieldBuilderRange::Range(range) => {
+                                            if range.end < range.start {
+                                                return Err(syn::Error::new(
+                                                    ident.span(),
+                                                    "range end is less than range start",
+                                                ));
+                                            }
+                                            if range.end - range.start
+                                                != sub_ty.size() * 8 * array_length
+                                            {
+                                                return Err(
+                                                    syn::Error::new(
+                                                        ident.span(),
+                                                        "Element arrays bit range didn't match (element bit size * array length)"
+                                                    )
+                                                );
+                                            }
+                                            FieldBuilderRange::Range(range)
+                                        }
+                                        FieldBuilderRange::LastEnd(last_end) => {
+                                            FieldBuilderRange::Range(
+                                                last_end
+                                                    ..last_end + (array_length * sub_ty.size() * 8),
+                                            )
+                                        }
+                                        _ => {
+                                            return Err(syn::Error::new(
+                                                ident.span(),
+                                                "failed getting Range for element array",
+                                            ));
+                                        }
+                                    };
+
+                                    let type_ident = &sub_ty.type_quote();
+                                    FieldDataType::ElementArray(
+                                        Box::new(SubFieldInfo { ty: sub_ty }),
+                                        array_length,
+                                        quote! {[#type_ident;#array_length]},
+                                    )
                                 }
                             }
                         } else {
@@ -305,7 +354,12 @@ impl FieldDataType {
                 if default_endianess.has_endianness() {
                     attrs.endianness = Box::new(default_endianess.clone());
                 } else {
-                    return Err(Error::new(ident.span(), "field without defined endianess found, please set endianess of struct or fields"));
+                    if data_type.size() == 1 {
+                        let mut big = Endianness::Big;
+                        std::mem::swap(attrs.endianness.as_mut(), &mut big);
+                    }else{
+                        return Err(Error::new(ident.span(), "field without defined endianess found, please set endianess of struct or fields"));
+                    }
                 }
             }
         }

--- a/bondrewd-derive/tests/be_primitives.rs
+++ b/bondrewd-derive/tests/be_primitives.rs
@@ -1,6 +1,4 @@
-use bondrewd::Bitfields;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
 #[bondrewd(default_endianness = "be")]

--- a/bondrewd-derive/tests/block_arrays.rs
+++ b/bondrewd-derive/tests/block_arrays.rs
@@ -1,6 +1,4 @@
-use bondrewd::Bitfields;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
 #[bondrewd(default_endianness = "be")]

--- a/bondrewd-derive/tests/ccsds.rs
+++ b/bondrewd-derive/tests/ccsds.rs
@@ -1,6 +1,4 @@
-use bondrewd::{BitfieldEnum, Bitfields};
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(BitfieldEnum, Clone, PartialEq, Eq, Debug)]
 pub enum CcsdsPacketSequenceFlags {

--- a/bondrewd-derive/tests/element_arrays.rs
+++ b/bondrewd-derive/tests/element_arrays.rs
@@ -1,6 +1,4 @@
-use bondrewd::Bitfields;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
 #[bondrewd(default_endianness = "be")]

--- a/bondrewd-derive/tests/enum_fields.rs
+++ b/bondrewd-derive/tests/enum_fields.rs
@@ -1,6 +1,4 @@
-use bondrewd::{BitfieldEnum, Bitfields};
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
 enum TestEnum {

--- a/bondrewd-derive/tests/hex.rs
+++ b/bondrewd-derive/tests/hex.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "hex_fns")]
+mod hex_tests {
+    use bondrewd::*;
+    #[derive(Bitfields, Clone, Debug, PartialEq)]
+    #[bondrewd(read_from = "lsb0", enforce_bits = 3)]
+    pub struct StatusMagnetometer {
+        int_mtm1: bool,
+        int_mtm2: bool,
+        ext_mtm: bool,
+    }
+
+    /// Response to a Get Mtm Reading command - returns data in the Telemetry::Magnetometer format (separate as non-unit enums are not supported by GraphQL)
+    /// This includes status and readings for all magnetometers
+    #[derive(Bitfields, Clone, Debug, PartialEq)]
+    #[bondrewd(default_endianness = "msb")]
+    pub struct Magnetometer {
+        pub timestamp: u64,
+        #[bondrewd(struct_size = 1)]
+        pub status: StatusMagnetometer,
+        #[bondrewd(block_byte_length = 6)]
+        pub int_mtm1_xyz: [i16; 3],
+        #[bondrewd(block_byte_length = 6)]
+        pub int_mtm2_xyz: [i16; 3],
+        #[bondrewd(block_byte_length = 6)]
+        pub ext_mtm_xyz: [i16; 3],
+    }
+    #[test]
+    fn hex_test(){
+        let og = Magnetometer {
+            timestamp: 063482412850,
+            status: StatusMagnetometer {
+                int_mtm1: true,
+                int_mtm2: false,
+                ext_mtm: true,
+            },
+            int_mtm1_xyz: [53, 6, 9246],
+            int_mtm2_xyz: [876, 29, 678],
+            ext_mtm_xyz: [485, 2534, 2],
+        };
+        let bytes = og.clone().into_bytes();
+        let mut hex_from_bytes = String::new();
+        for byte in bytes {
+            let hex_byte = format!("{:02X}", byte);
+            hex_from_bytes.push_str(hex_byte.as_str());
+        }
+        let hex = og.clone().into_hex_upper();
+        let mut hex_string = String::new();
+        for hex_char in hex {
+            hex_string.push(hex_char as char);
+        }
+        assert_eq!(hex_string, hex_from_bytes);
+
+        let from_bytes_obj = Magnetometer::from_bytes(bytes);
+        assert_eq!(from_bytes_obj, og);
+
+        let from_hex_obj = if let Ok(m) = Magnetometer::from_hex(hex) { m } else { panic!("Bad decode")};
+        assert_eq!(from_hex_obj, og);
+
+    }
+}

--- a/bondrewd-derive/tests/le_primitives.rs
+++ b/bondrewd-derive/tests/le_primitives.rs
@@ -1,6 +1,4 @@
-use bondrewd::Bitfields;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 
 #[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
 #[bondrewd(default_endianness = "le")]

--- a/bondrewd-derive/tests/structs.rs
+++ b/bondrewd-derive/tests/structs.rs
@@ -1,6 +1,4 @@
-use bondrewd::Bitfields;
-#[cfg(feature = "slice_fns")]
-use bondrewd::BitfieldSliceError;
+use bondrewd::*;
 #[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
 #[bondrewd(default_endianness = "be")]
 struct Simple {

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -12,8 +12,10 @@ repository = "https://github.com/Devlyn-Nelson/Bondrewd"
 
 [dependencies]
 bondrewd-derive = { path = "../bondrewd-derive", optional = true }
+thiserror = { version = "^1.0", optional = true }
 
 [features] 
-default = []
+default = ["hex_fns"]
 derive = ["bondrewd-derive"]
 slice_fns = ["bondrewd-derive/slice_fns"]
+hex_fns = ["thiserror"]

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 repository = "https://github.com/Devlyn-Nelson/Bondrewd"
 
 [dependencies]
-bondrewd-derive = { version = "0.2.9", optional = true }
+bondrewd-derive = { path = "../bondrewd-derive", optional = true }
 
 [features] 
 default = []

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -18,4 +18,4 @@ thiserror = { version = "^1.0", optional = true }
 default = ["hex_fns"]
 derive = ["bondrewd-derive"]
 slice_fns = ["bondrewd-derive/slice_fns"]
-hex_fns = ["thiserror"]
+hex_fns = ["bondrewd-derive/hex_fns"]

--- a/bondrewd/src/error.rs
+++ b/bondrewd/src/error.rs
@@ -12,5 +12,14 @@ impl std::fmt::Display for BitfieldSliceError {
         )
     }
 }
-
 impl std::error::Error for BitfieldSliceError {}
+#[cfg(feature = "hex_fns")]
+use thiserror::Error;
+#[cfg(feature = "hex_fns")]
+#[derive(Debug, Error)]
+pub enum BitfieldHexError {
+    #[error("expected {1} bytes, {0} bytes were provided.")]
+    InvaildSize(usize, usize),
+    #[error(transparent)]
+    HexRegexFailure(#[from] std::num::ParseIntError),
+}

--- a/bondrewd/src/error.rs
+++ b/bondrewd/src/error.rs
@@ -13,13 +13,16 @@ impl std::fmt::Display for BitfieldSliceError {
     }
 }
 impl std::error::Error for BitfieldSliceError {}
-#[cfg(feature = "hex_fns")]
-use thiserror::Error;
-#[cfg(feature = "hex_fns")]
-#[derive(Debug, Error)]
-pub enum BitfieldHexError {
-    #[error("expected {1} bytes, {0} bytes were provided.")]
-    InvaildSize(usize, usize),
-    #[error(transparent)]
-    HexRegexFailure(#[from] std::num::ParseIntError),
+
+#[derive(Debug)]
+pub struct BitfieldHexError(pub char, pub usize);
+
+impl std::fmt::Display for BitfieldHexError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            fmt,
+            "found Invalid character {} @ index {}.",
+            self.0, self.1
+        )
+    }
 }

--- a/bondrewd/src/lib.rs
+++ b/bondrewd/src/lib.rs
@@ -12,9 +12,17 @@ pub trait BitfieldEnum {
     fn into_primitive(self) -> Self::Primitive;
 }
 
+
 mod error;
 #[cfg(feature = "slice_fns")]
 pub use error::BitfieldSliceError;
+#[cfg(feature = "hex_fns")]
+pub use error::BitfieldHexError;
+#[cfg(feature = "hex_fns")]
+pub trait BitfieldHex<S = Self>{
+    fn from_hex_string(hex: String) -> Result<S, BitfieldHexError>;
+    fn into_hex_string(self) -> String;
+}
 
 // re-export the derive stuff
 #[cfg(feature = "derive")]

--- a/bondrewd/src/lib.rs
+++ b/bondrewd/src/lib.rs
@@ -19,9 +19,12 @@ pub use error::BitfieldSliceError;
 #[cfg(feature = "hex_fns")]
 pub use error::BitfieldHexError;
 #[cfg(feature = "hex_fns")]
-pub trait BitfieldHex<S = Self>{
-    fn from_hex_string(hex: String) -> Result<S, BitfieldHexError>;
-    fn into_hex_string(self) -> String;
+pub trait BitfieldHex<const SIZE: usize> where Self: Sized {
+    const UPPERS: &'static [u8; 16] = b"0123456789ABCDEF";
+    const LOWERS: &'static [u8; 16] = b"0123456789abcdef";
+    fn from_hex(hex: [u8;SIZE]) -> Result<Self, BitfieldHexError>;
+    fn into_hex_upper(self) -> [u8;SIZE];
+    fn into_hex_lower(self) -> [u8;SIZE];
 }
 
 // re-export the derive stuff


### PR DESCRIPTION
- 1 byte primitives no longer need their endianness defined.
- arrays with no attributes default to block array.
- fixed bug with block array that made them do terrible things.(bit_range math was bad, the first 2 values in a array were always treated the exact same).