### PR TITLE
Add in support for Enum Variant Discriminants

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ fn main() {
 # `enum` Derive features:
 
 * Derive from_primitive and into_primitive.
-* specify a Invalid variant for catching values that don't make sense. otherwise the last value will be used as a catch all.
+* Specify an `Invalid` variant for catching values that don't make sense, otherwise the last value will be used as a catch-all.
   * `#[bondrewd_enum(invalid)]`.
+* Specify custom `u8` literal for discriminants on enum variants 
 * Invalid with primitive. like the Invalid catch all above but it stores the value as a variant field.
 
 # Why Bondrewd

--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd-derive"
-version = "0.2.15"
+version = "0.3.0"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]

--- a/bondrewd-derive/src/enums/mod.rs
+++ b/bondrewd-derive/src/enums/mod.rs
@@ -1,3 +1,4 @@
 pub mod from_bytes;
 pub mod into_bytes;
 pub mod parse;
+pub mod partial_eq;

--- a/bondrewd-derive/src/enums/parse.rs
+++ b/bondrewd-derive/src/enums/parse.rs
@@ -333,6 +333,7 @@ impl EnumInfo {
                             variant_continuation_value = Some((discriminant_val as u16) + 1);
                         } else if let Some(val) = variant_continuation_value {
                             // Check to see if the next variant would cause an out of bounds generation
+                            // TODO: Check the size of the discriminant based on the `bit_length` of the underlying Enum?
                             if val > (u8::MAX as u16) {
                                 return Err(syn::Error::new(var.ident.span(), "variant value generates code out of range of u8"))
                             }

--- a/bondrewd-derive/src/enums/parse.rs
+++ b/bondrewd-derive/src/enums/parse.rs
@@ -47,6 +47,7 @@ pub struct EnumInfo {
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub primitive: Ident,
+    pub partial_eq: bool
 }
 
 enum ParseMetaResult {
@@ -192,6 +193,7 @@ impl EnumInfo {
             }
         };
         let mut primitive_type: Option<Ident> = None;
+        let mut partial_eq = false;
         for attr in &input.attrs {
             match attr.parse_meta()? {
                 Meta::NameValue(_) => {}
@@ -202,16 +204,23 @@ impl EnumInfo {
                             match nested_meta {
                                 NestedMeta::Meta(meta) => match meta {
                                     Meta::Path(path) => {
+                                        // Add an additional check to implement `partial_eq` optionally.
                                         if path.is_ident("u8") {
                                             primitive_type = Some(quote::format_ident!("u8"));
-                                            break;
+                                        } else if path.is_ident("partial_eq") {
+                                            partial_eq = true;
                                         } else {
                                             return Err(syn::Error::new(
                                                 input.ident.span(),
-                                                "the only supported enum type is u8 currently",
+                                                "the only supported enum attributes are u8, partial_eq currently",
                                             ));
                                         }
-                                    }
+
+                                        // Have we found all of the relevant attributes?
+                                        if primitive_type.is_some() && partial_eq {
+                                            break;
+                                        }
+                                    },
                                     _ => {}
                                 },
                                 NestedMeta::Lit(_) => {}
@@ -377,6 +386,7 @@ impl EnumInfo {
         let info = EnumInfo {
             name: input.ident.clone(),
             variants,
+            partial_eq,
             primitive: if let Some(prim) = primitive_type {
                 if prim.to_string().as_str() == "u8" {
                     prim

--- a/bondrewd-derive/src/enums/partial_eq.rs
+++ b/bondrewd-derive/src/enums/partial_eq.rs
@@ -40,15 +40,15 @@ pub fn generate_partial_eq(enum_info: &EnumInfo) -> proc_macro2::TokenStream {
     for var in enum_info.variants.iter() {
         let name = &var.name;
         let arm = match var.value {
-            EnumVariantType::UnsignedValue(v) => {
+            EnumVariantType::UnsignedValue(ref v) => {
                 quote! { (Self::#name, #v) => true, }
             },
-            EnumVariantType::CatchAll(_) => {
-                quote! { _ => false, }
-            },
-            EnumVariantType::CatchPrimitive => {
+            EnumVariantType::CatchAll(_) |
+            EnumVariantType::CatchPrimitive(_) |
+            EnumVariantType::Skip(_) => {
                 quote! { _ => false, }
             }
+            
         };
         comp_arms = quote! {
             #comp_arms

--- a/bondrewd-derive/src/enums/partial_eq.rs
+++ b/bondrewd-derive/src/enums/partial_eq.rs
@@ -1,0 +1,67 @@
+use crate::enums::parse::{EnumInfo, EnumVariantType};
+use quote::quote;
+
+/// Generates a `PartialEq` implementation for the given `enum_info`.
+/// N.B. The `PartialEq` implementation will only be generated iff `enum_partial_eq` feature is enabled.
+///
+/// This generates the equivalent of the following code:
+/// ```
+/// use bondrewd::*;
+///
+/// #[derive(BitfieldEnum)]
+/// #[bondrewd_enum(u8)]
+/// pub enum Test {
+///     Zero,
+///     One,
+///     Two,
+///     Invalid
+/// }
+///
+/// impl PartialEq<u8> for Test {
+///     fn eq(&self, other: &u8) -> bool {
+///         match (self, other) {
+///             (Self::Zero, 0) => true,
+///             (Self::One, 1) => true,
+///             (Self::Two, 2) => true,
+///             _ => false
+///         }
+///     }
+/// }
+/// ```
+pub fn generate_partial_eq(enum_info: &EnumInfo) -> proc_macro2::TokenStream {
+    // Short circuit if we're not generating parital_eq
+    if !enum_info.partial_eq {
+        return quote! {};
+    }
+
+    let mut comp_arms = quote! {};
+    let enum_name = &enum_info.name;
+    let primitive_ty = &enum_info.primitive;
+    for var in enum_info.variants.iter() {
+        let name = &var.name;
+        let arm = match var.value {
+            EnumVariantType::UnsignedValue(v) => {
+                quote! { (Self::#name, #v) => true, }
+            },
+            EnumVariantType::CatchAll(_) => {
+                quote! { _ => false, }
+            },
+            EnumVariantType::CatchPrimitive => {
+                quote! { _ => false, }
+            }
+        };
+        comp_arms = quote! {
+            #comp_arms
+            #arm
+        }
+    }
+    quote! {
+        impl std::cmp::PartialEq<#primitive_ty> for #enum_name {
+            fn eq(&self, other: &#primitive_ty) -> bool {
+                match (self, other) {
+                    #comp_arms
+                }
+            }
+        }
+    }
+}

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -408,6 +408,7 @@ pub fn derive_bitfields(input: TokenStream) -> TokenStream {
 ///                         variant will be used).
 /// - [x] Invalid catch (stores the actual primitive in a 1 field Variant).
 /// - [ ] types other than u8.
+/// - [x] Support `u8` literals for Enum Variants
 #[proc_macro_derive(BitfieldEnum, attributes(bondrewd_enum))]
 pub fn derive_bondrewd_enum(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -297,9 +297,13 @@ pub fn derive_bitfields(input: TokenStream) -> TokenStream {
 
     let setters: bool;
     #[cfg(not(feature = "setters"))]
-    {setters = false;}
+    {
+        setters = false;
+    }
     #[cfg(feature = "setters")]
-    {setters = true;}
+    {
+        setters = true;
+    }
     let setters_quote = if setters {
         match structs::struct_fns::create_into_bytes_field_quotes(&struct_info) {
             Ok(parsed_struct) => parsed_struct,
@@ -307,8 +311,8 @@ pub fn derive_bitfields(input: TokenStream) -> TokenStream {
                 return TokenStream::from(err.to_compile_error());
             }
         }
-    }else{
-        quote!{}
+    } else {
+        quote! {}
     };
 
     let getter_setters_quotes = quote! {
@@ -419,8 +423,14 @@ pub fn derive_bondrewd_enum(input: TokenStream) -> TokenStream {
             return TokenStream::from(err.to_compile_error());
         }
     };
-    let into = enums::into_bytes::generate_into_bytes(&enum_info);
-    let from = enums::from_bytes::generate_from_bytes(&enum_info);
+    let into = match enums::into_bytes::generate_into_bytes(&enum_info) {
+        Ok(i) => i,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
+    let from = match enums::from_bytes::generate_from_bytes(&enum_info) {
+        Ok(f) => f,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
     let partial_eq = enums::partial_eq::generate_partial_eq(&enum_info);
     let enum_name = enum_info.name;
     let primitive = enum_info.primitive;

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -409,6 +409,7 @@ pub fn derive_bitfields(input: TokenStream) -> TokenStream {
 /// - [x] Invalid catch (stores the actual primitive in a 1 field Variant).
 /// - [ ] types other than u8.
 /// - [x] Support `u8` literals for Enum Variants
+/// - [x] Support for impl of `std::cmp::PartialEq` for the given primitive (currently only u8)
 #[proc_macro_derive(BitfieldEnum, attributes(bondrewd_enum))]
 pub fn derive_bondrewd_enum(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -420,6 +421,7 @@ pub fn derive_bondrewd_enum(input: TokenStream) -> TokenStream {
     };
     let into = enums::into_bytes::generate_into_bytes(&enum_info);
     let from = enums::from_bytes::generate_from_bytes(&enum_info);
+    let partial_eq = enums::partial_eq::generate_partial_eq(&enum_info);
     let enum_name = enum_info.name;
     let primitive = enum_info.primitive;
     TokenStream::from(quote! {
@@ -428,5 +430,7 @@ pub fn derive_bondrewd_enum(input: TokenStream) -> TokenStream {
             #into
             #from
         }
+
+        #partial_eq
     })
 }

--- a/bondrewd-derive/src/structs/struct_fns.rs
+++ b/bondrewd-derive/src/structs/struct_fns.rs
@@ -1,17 +1,16 @@
 use crate::structs::common::{
     get_be_starting_index, get_left_and_mask, get_right_and_mask, BitMath, Endianness,
-    FieldDataType, FieldInfo, StructInfo, NumberSignage
+    FieldDataType, FieldInfo, NumberSignage, StructInfo,
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-
 
 pub fn create_into_bytes_field_quotes(info: &StructInfo) -> Result<TokenStream, syn::Error> {
     // all of the fields set functions that disallow numbers that are too large to fit into bit length.
     let mut set_fns_quote = quote! {};
     for field in info.fields.iter() {
         let q = make_set_field_quote(&field)?;
-        set_fns_quote = quote!{
+        set_fns_quote = quote! {
             #set_fns_quote
             #q
         };
@@ -155,14 +154,10 @@ fn make_set_field_quote(field: &FieldInfo) -> Result<TokenStream, syn::Error> {
             }
         }
         FieldDataType::ElementArray(ref fields, ref length, ref type_ident) => {
-            quote!{
-
-            }
+            quote! {}
         }
         FieldDataType::BlockArray(ref fields, size, ref type_ident) => {
-            quote!{
-
-            }
+            quote! {}
         }
         FieldDataType::Boolean => {
             let field_fn_name = format_ident!("set_{}", field_name);

--- a/bondrewd-derive/tests/enum_derives.rs
+++ b/bondrewd-derive/tests/enum_derives.rs
@@ -3,7 +3,7 @@ use bondrewd::BitfieldEnum;
 // for situation where all bits are accounted for, like if this enum was used as a 2bit field than
 // we can just let the last option be a valid catch all (in proc_macro code it is still marked as
 // an invalid catch all but that doesn't really matter)
-#[derive(BitfieldEnum)]
+#[derive(BitfieldEnum, PartialEq, Debug)]
 #[bondrewd_enum(u8)]
 enum NoInvalidEnum {
     Zero,
@@ -28,7 +28,7 @@ fn enum_auto_catch_all() {
     assert!(NoInvalidEnum::from_primitive(255u8).into_primitive() == 3);
 }
 
-#[derive(BitfieldEnum)]
+#[derive(BitfieldEnum, PartialEq, Debug)]
 #[bondrewd_enum(u8)]
 enum CenteredInvalid {
     BLue,
@@ -41,11 +41,13 @@ enum CenteredInvalid {
 
 #[test]
 fn enum_centered_catch_all() {
-    assert!(CenteredInvalid::from_primitive(0u8).into_primitive() == 0);
-    assert!(CenteredInvalid::from_primitive(1u8).into_primitive() == 1);
-    assert!(CenteredInvalid::from_primitive(2u8).into_primitive() == 2);
-    assert!(CenteredInvalid::from_primitive(3u8).into_primitive() == 3);
-    assert!(CenteredInvalid::from_primitive(4u8).into_primitive() == 4);
+    assert_eq!(CenteredInvalid::from_primitive(0u8).into_primitive(), 0);
+    assert_eq!(CenteredInvalid::from_primitive(1u8).into_primitive(), 1);
+    assert_eq!(CenteredInvalid::from_primitive(2u8).into_primitive(), 2);
+    let test = CenteredInvalid::from_primitive(3u8);
+    assert_eq!(CenteredInvalid::Three, test);
+    assert_eq!(test.into_primitive(), 3);
+    assert_eq!(CenteredInvalid::from_primitive(4u8).into_primitive(), 4);
 
     // test the catch all functionality
     assert_eq!(CenteredInvalid::from_primitive(5u8).into_primitive(), 2);
@@ -65,11 +67,11 @@ enum CenteredInvalidPrimitive {
 
 #[test]
 fn enum_centered_catch_primitive() {
-    assert!(CenteredInvalidPrimitive::from_primitive(0u8).into_primitive() == 0);
-    assert!(CenteredInvalidPrimitive::from_primitive(1u8).into_primitive() == 1);
-    assert!(CenteredInvalidPrimitive::from_primitive(2u8).into_primitive() == 2);
-    assert!(CenteredInvalidPrimitive::from_primitive(3u8).into_primitive() == 3);
-    assert!(CenteredInvalidPrimitive::from_primitive(4u8).into_primitive() == 4);
+    assert_eq!(CenteredInvalidPrimitive::from_primitive(0u8).into_primitive(), 0);
+    assert_eq!(CenteredInvalidPrimitive::from_primitive(1u8).into_primitive(), 1);
+    assert_eq!(CenteredInvalidPrimitive::from_primitive(2u8).into_primitive(), 2);
+    assert_eq!(CenteredInvalidPrimitive::from_primitive(3u8).into_primitive(), 3);
+    assert_eq!(CenteredInvalidPrimitive::from_primitive(4u8).into_primitive(), 4);
 
     // test the catch all functionality
     assert_eq!(

--- a/bondrewd-derive/tests/enum_fields_custom.rs
+++ b/bondrewd-derive/tests/enum_fields_custom.rs
@@ -33,14 +33,8 @@ fn to_bytes_simple_with_custom_enum_spanning() -> anyhow::Result<()> {
     #[cfg(feature = "slice_fns")]
     {
         //peeks
-        assert_eq!(
-            simple.one,
-            SimpleCustomEnumUsage::peek_slice_one(&bytes)?
-        );
-        assert_eq!(
-            simple.two,
-            SimpleCustomEnumUsage::peek_slice_two(&bytes)?
-        );
+        assert_eq!(simple.one, SimpleCustomEnumUsage::peek_slice_one(&bytes)?);
+        assert_eq!(simple.two, SimpleCustomEnumUsage::peek_slice_two(&bytes)?);
         assert_eq!(
             simple.three,
             SimpleCustomEnumUsage::peek_slice_three(&bytes)?
@@ -77,13 +71,13 @@ fn enum_contiunation_tests() -> anyhow::Result<()> {
     let simple = SimpleCustomContinuationEnumUsage {
         one: 0x80,
         two: TestCustomContinuationEnum::CustomOneContinued,
-        three: 0x08
+        three: 0x08,
     };
     assert_eq!(SimpleCustomContinuationEnumUsage::BYTE_SIZE, 3);
     let mut bytes = simple.clone().into_bytes();
     assert_eq!(bytes.len(), 3);
     assert_eq!(bytes[0], 0b10000000);
-    assert_eq!(bytes[1], 0b01000000);
+    assert_eq!(bytes[1], 0b00000001);
     assert_eq!(bytes[2], 0b00001000);
     #[cfg(feature = "slice_fns")]
     {
@@ -107,13 +101,18 @@ fn enum_contiunation_tests() -> anyhow::Result<()> {
     assert_eq!(simple, new_simple);
 
     // Setter too
-    SimpleCustomContinuationEnumUsage::write_slice_two(&mut bytes, TestCustomContinuationEnum::CustomZeroContinued);
-    assert_eq!(bytes[1], 0b10000000);
+    SimpleCustomContinuationEnumUsage::write_slice_two(
+        &mut bytes,
+        TestCustomContinuationEnum::CustomZeroContinued,
+    )?;
     let expected = SimpleCustomContinuationEnumUsage {
         one: 0x80,
         two: TestCustomContinuationEnum::CustomZeroContinued,
-        three: 0x08
+        three: 0x08,
     };
-    assert_eq!(SimpleCustomContinuationEnumUsage::from_bytes(bytes), expected);
+    assert_eq!(
+        SimpleCustomContinuationEnumUsage::from_bytes(bytes),
+        expected
+    );
     Ok(())
 }

--- a/bondrewd-derive/tests/enum_fields_custom.rs
+++ b/bondrewd-derive/tests/enum_fields_custom.rs
@@ -1,0 +1,120 @@
+use bondrewd::*;
+use crate::TestCustomContinuationEnum::CustomZeroContinued;
+
+#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
+#[bondrewd_enum(u8)]
+enum TestCustomEnum {
+    CustomZero = 0x30,
+    CustomOne = 0x10,
+    CustomTwo = 0x20,
+    CustomThree = 0x40,
+    Invalid,
+}
+
+#[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
+#[bondrewd(default_endianness = "be")]
+struct SimpleCustomEnumUsage {
+    one: u8,
+    #[bondrewd(enum_primitive = "u8", bit_length = 8)]
+    two: TestCustomEnum,
+    three: u8,
+}
+#[test]
+fn to_bytes_simple_with_custom_enum_spanning() -> anyhow::Result<()> {
+    let simple = SimpleCustomEnumUsage {
+        one: 0x08,
+        two: TestCustomEnum::CustomThree,
+        three: 0,
+    };
+    assert_eq!(SimpleCustomEnumUsage::BYTE_SIZE, 3);
+    let bytes = simple.clone().into_bytes();
+    assert_eq!(bytes.len(), 3);
+    assert_eq!(bytes[0], 0b00001000);
+    assert_eq!(bytes[1], 0b01000000);
+    #[cfg(feature = "slice_fns")]
+    {
+        //peeks
+        assert_eq!(
+            simple.one,
+            SimpleCustomEnumUsage::peek_slice_one(&bytes)?
+        );
+        assert_eq!(
+            simple.two,
+            SimpleCustomEnumUsage::peek_slice_two(&bytes)?
+        );
+        assert_eq!(
+            simple.three,
+            SimpleCustomEnumUsage::peek_slice_three(&bytes)?
+        );
+    }
+
+    // from_bytes
+    let new_simple = SimpleCustomEnumUsage::from_bytes(bytes);
+    assert_eq!(simple, new_simple);
+    Ok(())
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
+#[bondrewd_enum(u8)]
+enum TestCustomContinuationEnum {
+    CustomZero = 0x7F,
+    CustomZeroContinued,
+    CustomOne = 0x3F,
+    CustomOneContinued,
+    Invalid,
+}
+
+#[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
+#[bondrewd(default_endianness = "be")]
+struct SimpleCustomContinuationEnumUsage {
+    one: u8,
+    #[bondrewd(enum_primitive = "u8", bit_length = 8)]
+    two: TestCustomContinuationEnum,
+    three: u8,
+}
+
+#[test]
+fn enum_contiunation_tests() -> anyhow::Result<()> {
+    let simple = SimpleCustomContinuationEnumUsage {
+        one: 0x80,
+        two: TestCustomContinuationEnum::CustomOneContinued,
+        three: 0x08
+    };
+    assert_eq!(SimpleCustomContinuationEnumUsage::BYTE_SIZE, 3);
+    let mut bytes = simple.clone().into_bytes();
+    assert_eq!(bytes.len(), 3);
+    assert_eq!(bytes[0], 0b10000000);
+    assert_eq!(bytes[1], 0b01000000);
+    assert_eq!(bytes[2], 0b00001000);
+    #[cfg(feature = "slice_fns")]
+    {
+        //peeks
+        assert_eq!(
+            simple.one,
+            SimpleCustomContinuationEnumUsage::peek_slice_one(&bytes)?
+        );
+        assert_eq!(
+            simple.two,
+            SimpleCustomContinuationEnumUsage::peek_slice_two(&bytes)?
+        );
+        assert_eq!(
+            simple.three,
+            SimpleCustomContinuationEnumUsage::peek_slice_three(&bytes)?
+        );
+    }
+
+    // from bytes
+    let new_simple = SimpleCustomContinuationEnumUsage::from_bytes(bytes);
+    assert_eq!(simple, new_simple);
+
+    // Setter too
+    SimpleCustomContinuationEnumUsage::write_slice_two(&mut bytes, TestCustomContinuationEnum::CustomZeroContinued);
+    assert_eq!(bytes[1], 0b10000000);
+    let expected = SimpleCustomContinuationEnumUsage {
+        one: 0x80,
+        two: TestCustomContinuationEnum::CustomZeroContinued,
+        three: 0x08
+    };
+    assert_eq!(SimpleCustomContinuationEnumUsage::from_bytes(bytes), expected);
+    Ok(())
+}

--- a/bondrewd-derive/tests/enum_fields_custom.rs
+++ b/bondrewd-derive/tests/enum_fields_custom.rs
@@ -1,5 +1,4 @@
 use bondrewd::*;
-use crate::TestCustomContinuationEnum::CustomZeroContinued;
 
 #[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
 #[bondrewd_enum(u8)]

--- a/bondrewd-derive/tests/enum_partial_eq.rs
+++ b/bondrewd-derive/tests/enum_partial_eq.rs
@@ -1,0 +1,63 @@
+use bondrewd::*;
+
+#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
+#[bondrewd_enum(u8, partial_eq)]
+enum TestPartialEqEnum {
+    Zero,
+    One,
+    Two,
+    Three,
+    Invalid,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
+#[bondrewd_enum(u8, partial_eq)]
+enum TestPartialEqCustomEnum {
+    CustomZero = 0x10,
+    CustomOne = 0x20,
+    CustomTwo = 0x30,
+    CustomThree = 0x40,
+    Invalid,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
+#[bondrewd_enum(u8)]
+enum TestNoPartialEqCustomEnum {
+    CustomZero = 0x10,
+    CustomOne = 0x20,
+    CustomTwo = 0x30,
+    CustomThree = 0x40,
+    Invalid,
+}
+
+#[test]
+fn enum_partial_eq_tests() -> anyhow::Result<()> {
+    // Create some enums and compare directly to numbers
+    let simple_one = TestPartialEqEnum::One;
+    let simple_three = TestPartialEqEnum::Three;
+    let simple_invalid = TestPartialEqEnum::Invalid;
+
+    assert_eq!(simple_one, 1 as u8);
+    assert_eq!(simple_three, 3 as u8);
+    for i in 0..u8::MAX {
+        assert_ne!(simple_invalid, i);
+    }
+
+    // Create some custom enums
+    let custom_one = TestPartialEqCustomEnum::CustomOne;
+    let custom_three = TestPartialEqCustomEnum::CustomThree;
+    let custom_invalid = TestPartialEqCustomEnum::Invalid;
+
+    assert_eq!(custom_one, 0x20 as u8);
+    assert_eq!(custom_three, 0x40 as u8);
+    for i in 0..u8::MAX {
+        assert_ne!(custom_invalid, i);
+    }
+
+    // Test against a non partial_eq enum too
+    let no_partial_one = TestNoPartialEqCustomEnum::CustomOne;
+    let no_partial_three = TestNoPartialEqCustomEnum::CustomThree;
+    assert_eq!(no_partial_one.into_primitive(), 0x20);
+    assert_eq!(no_partial_three.into_primitive(), 0x40);
+    Ok(())
+}


### PR DESCRIPTION
Adds in support for Enum Variant Discriminants when parsing into/from bytes. For example, the following is now supported:

```rust
#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
#[bondrewd_enum(u8)]
enum CustomEnum {
    CustomZero = 0x30,
    CustomOne = 0x10,
    CustomTwo = 0x20,
    CustomThree = 0x40,
    Invalid,
}

#[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
#[bondrewd(default_endianness = "be")]
struct CustomEnumUsage {
    one: u8,
    #[bondrewd(enum_primitive = "u8", bit_length = 8)]
    two: TestCustomEnum,
    three: u8,
}

fn main() {
    let simple = CustomEnumUsage {
        one: 0x08,
        two: CustomEnum::CustomThree,
        three: 0,
    };
    let bytes = simple.clone().into_bytes();
    assert_eq!(bytes[1], 0b01000000); // Same as 0x40 (CustomEnum::CustomThree)
}
```

This also supports continuation of discrimination value in successive variants, replicating Rust behavior like:

```rust
#[derive(Eq, PartialEq, Clone, Debug, BitfieldEnum)]
#[bondrewd_enum(u8)]
enum CustomContinuationEnum {
    CustomZero = 0x7F,
    CustomZeroContinued,
    CustomOne = 0x3F,
    CustomOneContinued,
    Invalid,
}

#[derive(Bitfields, Clone, PartialEq, Eq, Debug)]
#[bondrewd(default_endianness = "be")]
struct CustomContinuationEnumUsage {
    one: u8,
    #[bondrewd(enum_primitive = "u8", bit_length = 8)]
    two: CustomContinuationEnum,
    three: u8,
}

fn main() {
    let simple = CustomContinuationEnumUsage {
        one: 0x80,
        two: CustomContinuationEnum::CustomOneContinued,
        three: 0x08
    };
    let mut bytes = simple.clone().into_bytes();
    assert_eq!(bytes[1], 0b01000000);
}
```

(See: tests/enum_fields_custom.rs for more details)