### PR TITLE
Checked Slice Structures

### DIFF
--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd-derive"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]

--- a/bondrewd-derive/Cargo.toml
+++ b/bondrewd-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd-derive"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -16,14 +16,25 @@ fn main() -> anyhow::Result<()> {
         two: true,
         three: 1,
     };
-    let bytes = test.into_bytes();
+    let mut bytes = test.into_bytes();
     if let Ok(checked_struct) = Simple::check_slice(&bytes){
-        assert_eq!(checked_struct.one(), 2);
-        assert_eq!(checked_struct.two(), true);
-        assert_eq!(checked_struct.three(), 1);
+        assert_eq!(checked_struct.read_one(), 2);
+        assert_eq!(checked_struct.read_two(), true);
+        assert_eq!(checked_struct.read_three(), 1);
     }else{
         panic!("check failed");
     };
     assert_eq!(bytes, [0b0010_1001]);
+    if let Ok(mut checked_struct) = Simple::check_slice_mut(&mut bytes){
+        checked_struct.write_one(4);
+        checked_struct.write_two(false);
+        checked_struct.write_three(2);
+        assert_eq!(checked_struct.read_one(), 4);
+        assert_eq!(checked_struct.read_two(), false);
+        assert_eq!(checked_struct.read_three(), 2);
+    }else{
+        panic!("mut check failed");
+    };
+    assert_eq!(bytes, [0b0100_0010]);
     Ok(())
 }

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -1,20 +1,29 @@
 use bondrewd::*;
 
-#[derive(Bitfields)]
+#[derive(Bitfields, Clone)]
 #[bondrewd(default_endianness = "be")]
-struct SimpleWithArray {
-    #[bondrewd(element_bit_length = 4)]
-    one: [u8; 4],
-    two: [bool; 5],
-    #[bondrewd(block_bit_length = 20)]
-    three: [u8; 3],
+struct Simple {
+    #[bondrewd(bit_length = 4)]
+    one: u8,
+    two: bool,
+    #[bondrewd(bit_length = 3)]
+    three: u8,
 }
 
-fn main(){
-    let test = SimpleWithArray {
-        one: [0b11110000, 0b00001111, 0b11110000, 0b00001001],
-        two: [false, true, false, true, false],
-        three: [u8::MAX, 0, 0b10101010],
+fn main() -> anyhow::Result<()> {
+    let test = Simple {
+        one: 2,
+        two: true,
+        three: 1,
     };
-    assert_eq!(test.into_bytes(), [0b0000_1111, 0b0000_1001, 0b01010_111, 0b1_0000000, 0b0_1010101, 0b0_0000000]);
+    let bytes = test.into_bytes();
+    if let Ok(checked_struct) = Simple::check_slice(&bytes){
+        assert_eq!(checked_struct.one(), 2);
+        assert_eq!(checked_struct.two(), true);
+        assert_eq!(checked_struct.three(), 1);
+    }else{
+        panic!("check failed");
+    };
+    assert_eq!(bytes, [0b0010_1001]);
+    Ok(())
 }

--- a/bondrewd-derive/examples/test.rs
+++ b/bondrewd-derive/examples/test.rs
@@ -2,10 +2,12 @@ use bondrewd::*;
 
 #[derive(Bitfields, Clone)]
 #[bondrewd(default_endianness = "be")]
+///
 struct Simple {
     #[bondrewd(bit_length = 4)]
     one: u8,
     two: bool,
+    /// hello
     #[bondrewd(bit_length = 3)]
     three: u8,
 }

--- a/bondrewd-derive/fuzz/fuzz_targets/primitives_be.rs
+++ b/bondrewd-derive/fuzz/fuzz_targets/primitives_be.rs
@@ -155,6 +155,21 @@ fuzz_target!(|data: [TestInnerArb;2]| {
     test.test_struct.set_f_two(data[0].f_two);
     test.test_struct.set_b_one(data[0].b_one);
     let bytes = test.clone().into_bytes();
+
+    if let Ok(checked) = Test::check_slice(&bytes) {
+        assert_eq!(checked.one(), test.one);
+        assert_eq!(checked.two(), test.two);
+        assert_eq!(checked.three(), test.three);
+        assert_eq!(checked.four(), test.four);
+        assert_eq!(checked.five(), test.five);
+        assert_eq!(checked.six(), test.six);
+        assert_eq!(checked.seven(), test.seven);
+        assert_eq!(checked.eight(), test.eight);
+        assert_eq!(checked.nine(), test.nine);
+        assert_eq!(checked.ten(), test.ten);
+    }else{
+        panic!("checking slice failed");
+    }
     
     let new_test = Test::from_bytes(bytes);
     assert_eq!(new_test, test);

--- a/bondrewd-derive/fuzz/fuzz_targets/primitives_le.rs
+++ b/bondrewd-derive/fuzz/fuzz_targets/primitives_le.rs
@@ -155,6 +155,21 @@ fuzz_target!(|data: [TestInnerArb;2]| {
     test.test_struct.set_f_two(data[0].f_two);
     test.test_struct.set_b_one(data[0].b_one);
     let bytes = test.clone().into_bytes();
+
+    if let Ok(checked) = Test::check_slice(&bytes) {
+        assert_eq!(checked.one(), test.one);
+        assert_eq!(checked.two(), test.two);
+        assert_eq!(checked.three(), test.three);
+        assert_eq!(checked.four(), test.four);
+        assert_eq!(checked.five(), test.five);
+        assert_eq!(checked.six(), test.six);
+        assert_eq!(checked.seven(), test.seven);
+        assert_eq!(checked.eight(), test.eight);
+        assert_eq!(checked.nine(), test.nine);
+        assert_eq!(checked.ten(), test.ten);
+    }else{
+        panic!("checking slice failed");
+    }
     
     let new_test = Test::from_bytes(bytes);
     assert_eq!(new_test, test);

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -110,13 +110,13 @@
 //! * multiple field access
 //!     * `fn check_slice(&[u8]) -> Result<{struct_name}Checked, bondrewd::BondrewdSliceError> { .. }`
 //!       this function will check the size of the slice, if the slice is big enough it will return
-//!       a structure with no fields. the structure will be the same name as the input structure with
+//!       a checked structure. the structure will be the same name as the input structure with
 //!       "Checked" tacked onto the end. the Checked Structure will have getters for each of the input
 //!       structures fields, the naming is the same as the standard `read_{field}` functions.
 //!         * `fn read_{field}(&self) -> {field_type} { .. }`
 //!     * `fn check_slice_mut(&mut [u8]) -> Result<{struct_name}CheckedMut, bondrewd::BondrewdSliceError> { .. }`
 //!       this function will check the size of the slice, if the slice is big enough it will return
-//!       a structure with no fields. the structure will be the same name as the input structure with
+//!       a checked structure. the structure will be the same name as the input structure with
 //!       "CheckedMut" tacked onto the end. the Checked Structure will have getters and setters for each
 //!       of the input structures fields, the naming is the same as the standard `read_{field}` and
 //!       `write_{field}` functions.
@@ -133,21 +133,41 @@
 //!     pub fn read_slice_two(input_byte_buffer: &[u8]) -> Result<bool, BitfieldSliceError> { .. }
 //!     #[inline]
 //!     pub fn read_slice_three(input_byte_buffer: &[u8]) -> Result<u8, BitfieldSliceError> { .. }
+//!     pub fn check_slice_mut(buffer: &mut [u8]) -> Result<SimpleCheckedMut, BitfieldSliceError> { .. }
 //!     #[inline]
-//!     pub fn write_slice_one(output_byte_buffer: &mut [u8], one: u8) -> Result<(), BitfieldSliceError> { .. }
+//!     pub fn write_slice_one(output_byte_buffer: &mut [u8],one: u8) -> Result<(), BitfieldSliceError> { .. }
 //!     #[inline]
-//!     pub fn write_slice_two(output_byte_buffer: &mut [u8], two: bool) -> Result<(), BitfieldSliceError> { .. }
+//!     pub fn write_slice_two(output_byte_buffer: &mut [u8],two: bool) -> Result<(), BitfieldSliceError> { .. }
 //!     #[inline]
-//!     pub fn write_slice_three(output_byte_buffer: &mut [u8], three: u8) -> Result<(), BitfieldSliceError> { .. }
+//!     pub fn write_slice_three(output_byte_buffer: &mut [u8],three: u8) -> Result<(), BitfieldSliceError> { .. }
 //! }
 //! struct SimpleChecked<'a> {
 //!     buffer: &'a [u8],
 //! }
-//! impl<'a> SimpleChecked<'a> { .. }
+//! impl<'a> SimpleChecked<'a> {
+//!     #[inline]
+//!     pub fn read_one(&self) -> u8 { .. }
 //!     #[inline]
 //!     pub fn read_two(&self) -> bool { .. }
 //!     #[inline]
 //!     pub fn read_three(&self) -> u8 { .. }
+//! }
+//! struct SimpleCheckedMut<'a> {
+//!     buffer: &'a mut [u8],
+//! }
+//! impl<'a> SimpleCheckedMut<'a> {
+//!     #[inline]
+//!     pub fn read_one(&self) -> u8 { .. }
+//!     #[inline]
+//!     pub fn read_two(&self) -> bool { .. }
+//!     #[inline]
+//!     pub fn read_three(&self) -> u8 { .. }
+//!     #[inline]
+//!     pub fn write_one(&mut self, one: u8) { .. }
+//!     #[inline]
+//!     pub fn write_two(&mut self, two: bool) { .. }
+//!     #[inline]
+//!     pub fn write_three(&mut self, three: u8) { .. }
 //! }
 //! ```
 //! 

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -104,36 +104,41 @@
 //! # Crate Features
 //! Slice functions are convenience functions for reading/wring single or multiple fields without reading
 //! the entire structure. Bondrewd will provided 2 ways to access the field:
-//! * single field access
+//! * Single field access. These are functions that are added along side the standard read/write field
+//! functions in the impl for the input structure. read/write slice functions will check the length of
+//! the slice to insure the amount to bytes needed for the field (NOT the entire structure) are present and
+//! return BitfieldSliceError if not enough bytes are present.
 //!     * `fn read_slice_{field}(&[u8]) -> Result<{field_type}, bondrewd::BondrewdSliceError> { .. }`
 //!     * `fn write_slice_{field}(&mut [u8], {field_type}) -> Result<(), bondrewd::BondrewdSliceError> { .. }`
-//! * multiple field access
+//! * Multiple field access.
 //!     * `fn check_slice(&[u8]) -> Result<{struct_name}Checked, bondrewd::BondrewdSliceError> { .. }`
-//!       this function will check the size of the slice, if the slice is big enough it will return
+//!       This function will check the size of the slice, if the slice is big enough it will return
 //!       a checked structure. the structure will be the same name as the input structure with
 //!       "Checked" tacked onto the end. the Checked Structure will have getters for each of the input
 //!       structures fields, the naming is the same as the standard `read_{field}` functions.
 //!         * `fn read_{field}(&self) -> {field_type} { .. }`
 //!     * `fn check_slice_mut(&mut [u8]) -> Result<{struct_name}CheckedMut, bondrewd::BondrewdSliceError> { .. }`
-//!       this function will check the size of the slice, if the slice is big enough it will return
+//!       This function will check the size of the slice, if the slice is big enough it will return
 //!       a checked structure. the structure will be the same name as the input structure with
 //!       "CheckedMut" tacked onto the end. the Checked Structure will have getters and setters for each
 //!       of the input structures fields, the naming is the same as the standard `read_{field}` and
 //!       `write_{field}` functions.
 //!         * `fn read_{field}(&self) -> {field_type} { .. }`
 //!         * `fn write_{field}(&mut self) -> {field_type} { .. }`
-//! Slice Example API generated: example Cargo.toml Bondrewd dependency
-//! `bondrewd = { version = "^0.1", features = ["derive", "slice_fns"] }`
+//!   
+//! Example Cargo.toml Bondrewd dependency  
+//! `bondrewd = { version = "^0.1", features = ["derive", "slice_fns"] }`  
+//! Example Generated Slice Api:
 //! ```compile_fail
 //! impl Simple {
 //!     pub fn check_slice(buffer: &[u8]) -> Result<SimpleChecked, BitfieldSliceError> { .. }
+//!     pub fn check_slice_mut(buffer: &mut [u8]) -> Result<SimpleCheckedMut, BitfieldSliceError> { .. }
 //!     #[inline]
 //!     pub fn read_slice_one(input_byte_buffer: &[u8]) -> Result<u8, BitfieldSliceError> { .. }
 //!     #[inline]
 //!     pub fn read_slice_two(input_byte_buffer: &[u8]) -> Result<bool, BitfieldSliceError> { .. }
 //!     #[inline]
 //!     pub fn read_slice_three(input_byte_buffer: &[u8]) -> Result<u8, BitfieldSliceError> { .. }
-//!     pub fn check_slice_mut(buffer: &mut [u8]) -> Result<SimpleCheckedMut, BitfieldSliceError> { .. }
 //!     #[inline]
 //!     pub fn write_slice_one(output_byte_buffer: &mut [u8],one: u8) -> Result<(), BitfieldSliceError> { .. }
 //!     #[inline]

--- a/bondrewd-derive/src/lib.rs
+++ b/bondrewd-derive/src/lib.rs
@@ -1177,7 +1177,25 @@ pub fn derive_bitfields(input: TokenStream) -> TokenStream {
         #hex_fns_quote
     };
 
+    #[cfg(feature = "slice_fns")]
+    {
+        let vis = struct_info.vis;
+        let checked_ident = format_ident!("{}Checked", &struct_name);
+        let unchecked_functions = fields_from_bytes.peek_slice_field_unchecked_fns;
+        let to_bytes_quote = quote!{
+            #to_bytes_quote
+            #vis struct #checked_ident<'a> {
+                buffer: &'a [u8],
+            }
+            impl<'a> #checked_ident<'a> {
+                #unchecked_functions
+            }
+        };
+        return TokenStream::from(to_bytes_quote);
+    }
     TokenStream::from(to_bytes_quote)
+
+    
 }
 
 /// Generates an implementation of bondrewd::BitfieldEnum trait.

--- a/bondrewd-derive/src/structs/common.rs
+++ b/bondrewd-derive/src/structs/common.rs
@@ -842,7 +842,6 @@ pub enum StructEnforcement {
     EnforceBitAmount(usize),
 }
 
-#[derive(Debug)]
 pub struct StructInfo {
     pub name: Ident,
     /// if false then bit 0 is the Most Significant Bit meaning the first values first bit will start there.
@@ -855,6 +854,7 @@ pub struct StructInfo {
     pub fields: Vec<FieldInfo>,
     pub default_endianess: Endianness,
     pub fill_bits: Option<usize>,
+    pub vis: syn::Visibility,
 }
 
 impl StructInfo {
@@ -989,6 +989,7 @@ impl StructInfo {
             fields: Default::default(),
             default_endianess: Endianness::None,
             fill_bits: None,
+            vis: input.vis.clone(),
         };
         for attr in input.attrs.iter() {
             let meta = attr.parse_meta()?;

--- a/bondrewd-derive/src/structs/from_bytes.rs
+++ b/bondrewd-derive/src/structs/from_bytes.rs
@@ -141,6 +141,7 @@ fn make_peek_slice_fn(
         (field.attrs.bit_range.end as f64 / 8.0f64).ceil() as usize
     };
     Ok(quote! {
+        #[inline]
         pub fn #field_name(input_byte_buffer: &[u8]) -> Result<#type_ident, BitfieldSliceError> {
             let slice_length = input_byte_buffer.len();
             if slice_length < #min_length {
@@ -158,9 +159,10 @@ fn make_peek_slice_unchecked_fn(
     field_quote: &TokenStream,
     field: &FieldInfo,
 ) -> syn::Result<TokenStream> {
-    let field_name = format_ident!("{}", field.ident.as_ref().clone());
+    let field_name = format_ident!("read_{}", field.ident.as_ref().clone());
     let type_ident = field.ty.type_quote();
     Ok(quote! {
+        #[inline]
         pub fn #field_name(&self) -> #type_ident {
             let input_byte_buffer: &[u8] = self.buffer;
             #field_quote

--- a/bondrewd-derive/src/structs/from_bytes.rs
+++ b/bondrewd-derive/src/structs/from_bytes.rs
@@ -12,6 +12,7 @@ pub struct FromBytesOptions {
     pub from_bytes_fn: TokenStream,
     pub peek_field_fns: TokenStream,
     pub peek_slice_field_fns: Option<TokenStream>,
+    pub peek_slice_field_unchecked_fns: Option<TokenStream>,
 }
 
 pub fn create_from_bytes_field_quotes(
@@ -22,8 +23,27 @@ pub fn create_from_bytes_field_quotes(
     let mut from_bytes_struct_quote = quote! {};
     // all of the fields extraction will be appended to this
     let mut from_bytes_quote = quote! {};
-    // all quote with all of the peek slice functions appended to it.
-    let mut peek_slice_fns_quote = quote! {};
+    // all quote with all of the peek slice functions appended to it. the second tokenstream is an unchecked
+    // version for the checked_struct.
+    let mut peek_slice_fns_option: Option<(TokenStream, TokenStream)> = if peek_slice {
+        let checked_ident = format_ident!("{}Checked", &info.name);
+        let check_size = info.total_bytes();
+        Some((
+            quote! {
+                pub fn check_slice(buffer: &[u8]) -> Result<#checked_ident, BitfieldSliceError> {
+                    let buf_len = buffer.len();
+                    if buf_len >= #check_size {
+                        Ok(#checked_ident {
+                            buffer
+                        })
+                    }else{
+                        Err(BitfieldSliceError(buf_len, #check_size))
+                    }
+                }
+            },
+            quote! {}
+        ))
+    } else { None };
     // all quote with all of the peek functions appended to it.
     let mut peek_fns_quote = quote! {};
     for field in info.fields.iter() {
@@ -62,12 +82,19 @@ pub fn create_from_bytes_field_quotes(
             #peek_quote
         };
 
-        if peek_slice {
+        if let Some((ref mut the_peek_slice_fns_quote, ref mut unchecked_quote)) = peek_slice_fns_option {
             let peek_slice_quote = make_peek_slice_fn(&field_extractor, &field, &info)?;
-            peek_slice_fns_quote = quote! {
-                #peek_slice_fns_quote
+            let peek_slice_unchecked_quote = make_peek_slice_unchecked_fn(&field_extractor, &field)?;
+            let mut the_peek_slice_fns_quote_temp = quote! {
+                #the_peek_slice_fns_quote
                 #peek_slice_quote
             };
+            let mut unchecked_quote_temp = quote!{
+                #unchecked_quote
+                #peek_slice_unchecked_quote
+            };
+            std::mem::swap(the_peek_slice_fns_quote, &mut the_peek_slice_fns_quote_temp);
+            std::mem::swap(unchecked_quote, &mut unchecked_quote_temp);
         }
     }
     let struct_size = &info.total_bytes();
@@ -84,15 +111,21 @@ pub fn create_from_bytes_field_quotes(
             }
         }
     };
-    Ok(FromBytesOptions {
-        from_bytes_fn,
-        peek_field_fns: peek_fns_quote,
-        peek_slice_field_fns: if peek_slice {
-            Some(peek_slice_fns_quote)
-        } else {
-            None
-        },
-    })
+    if let Some((peek_slice_field_fns, peek_slice_field_unchecked_fns)) = peek_slice_fns_option {
+        Ok(FromBytesOptions {
+            from_bytes_fn,
+            peek_field_fns: peek_fns_quote,
+            peek_slice_field_fns: Some(peek_slice_field_fns),
+            peek_slice_field_unchecked_fns: Some(peek_slice_field_unchecked_fns),
+        })
+    }else{
+        Ok(FromBytesOptions {
+            from_bytes_fn,
+            peek_field_fns: peek_fns_quote,
+            peek_slice_field_fns: None,
+            peek_slice_field_unchecked_fns: None,
+        })
+    }
 }
 
 fn make_peek_slice_fn(
@@ -117,6 +150,20 @@ fn make_peek_slice_fn(
                     #field_quote
                 )
             }
+        }
+    })
+}
+
+fn make_peek_slice_unchecked_fn(
+    field_quote: &TokenStream,
+    field: &FieldInfo,
+) -> syn::Result<TokenStream> {
+    let field_name = format_ident!("{}", field.ident.as_ref().clone());
+    let type_ident = field.ty.type_quote();
+    Ok(quote! {
+        pub fn #field_name(&self) -> #type_ident {
+            let input_byte_buffer: &[u8] = self.buffer;
+            #field_quote
         }
     })
 }

--- a/bondrewd-derive/src/structs/parse.rs
+++ b/bondrewd-derive/src/structs/parse.rs
@@ -532,7 +532,7 @@ impl FieldAttrBuilder {
                             }
                         }
                         _ => {
-                            if ident_as_str.as_str() != "" {
+                            if ident_as_str.as_str() != "doc" {
                                 return Err(Error::new(
                                     builder.span(),
                                     format!("\"{}\" is not a valid attribute", ident_as_str),

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bondrewd"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Bit-Level field packing with proc_macros"
 authors = ["Dev <devlynknelson@gmail.com>"]
@@ -11,7 +11,7 @@ readme = "../README.md"
 repository = "https://github.com/Devlyn-Nelson/Bondrewd"
 
 [dependencies]
-bondrewd-derive = { path = "../bondrewd-derive", optional = true }
+bondrewd-derive = { version = "^0.3", optional = true }
 
 [features]
 derive = ["bondrewd-derive"]

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 repository = "https://github.com/Devlyn-Nelson/Bondrewd"
 
 [dependencies]
-bondrewd-derive = { version = "0.3.7", optional = true }
+bondrewd-derive = { path = "../bondrewd-derive", optional = true }
 
 [features]
 derive = ["bondrewd-derive"]


### PR DESCRIPTION
added Checked Slice Structure types that allow for unchecked read_slice and write_slice functions for each field. this makes it so you can read/write multiple fields in a slice without needing to do a size check each time.