### PR TITLE
Mark Crate as no_std

### DIFF
--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -18,3 +18,4 @@ bondrewd-derive = { version = "^0.3", optional = true }
 derive = ["bondrewd-derive"]
 slice_fns = ["bondrewd-derive/slice_fns"]
 hex_fns = ["bondrewd-derive/hex_fns"]
+std = []

--- a/bondrewd/Cargo.toml
+++ b/bondrewd/Cargo.toml
@@ -15,6 +15,7 @@ bondrewd-derive = { version = "^0.3", optional = true }
 #bondrewd-derive = { path = "../bondrewd-derive", optional = true }
 
 [features]
+default = ["std"]
 derive = ["bondrewd-derive"]
 slice_fns = ["bondrewd-derive/slice_fns"]
 hex_fns = ["bondrewd-derive/hex_fns"]

--- a/bondrewd/src/error.rs
+++ b/bondrewd/src/error.rs
@@ -3,8 +3,8 @@
 #[derive(Debug)]
 pub struct BitfieldSliceError(pub usize, pub usize);
 
-impl std::fmt::Display for BitfieldSliceError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for BitfieldSliceError {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             fmt,
             "expected {} bytes, {} bytes were provided.",
@@ -12,13 +12,15 @@ impl std::fmt::Display for BitfieldSliceError {
         )
     }
 }
+
+#[cfg(feature = "std")]
 impl std::error::Error for BitfieldSliceError {}
 
 #[derive(Debug)]
 pub struct BitfieldHexError(pub char, pub usize);
 
-impl std::fmt::Display for BitfieldHexError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for BitfieldHexError {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             fmt,
             "found Invalid character {} @ index {}.",

--- a/bondrewd/src/lib.rs
+++ b/bondrewd/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Defined Traits for bondrewd-derive.
 //! For Derive Docs see [bondrewd-derive](https://docs.rs/bondrewd-derive/latest/bondrewd_derive/)
 pub trait Bitfields<const SIZE: usize> {


### PR DESCRIPTION
This fixes #10. 

I marked the bondrewd crate as no_std and added a std-feature which can be enabled to let the Error type still implement `std::error::Error`.